### PR TITLE
New BottomSheet that can change state internally

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -139,6 +139,19 @@ class _MyHomePageState extends State<MyHomePage> {
                               builder: (context) => ModalInsideModal(),
                             )),
                     ListTile(
+                        title: Text('Bar Modal with Notifier'),
+                        onTap: () => showBarModalBottomSheetWithNotifier(
+                              expand: true,
+                              context: context,
+                              backgroundColor: Colors.transparent,
+                              builder: (context) => ModalInsideModal(),
+                              // Change this to BottomSheetState.dismissible 
+                              // to see the difference
+                              changeInternalStateNotifier: ValueNotifier(
+                                BottomSheetState.nonDismissible,
+                              ),
+                            )),
+                    ListTile(
                         title: Text('Avatar Modal'),
                         onTap: () => showAvatarModalBottomSheet(
                               expand: true,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -12,10 +12,14 @@ import 'modals/modal_inside_modal.dart';
 import 'modals/modal_will_scope.dart';
 import 'modals/modal_with_navigator.dart';
 import 'modals/modal_with_nested_scroll.dart';
+import 'modals/modal_with_notifier.dart';
 import 'modals/modal_with_scroll.dart';
 import 'modals/modal_with_page_view.dart';
 
 import 'examples/cupertino_share.dart';
+
+ValueNotifier<BottomSheetState> bottomSheetStateNotifier =
+    ValueNotifier(BottomSheetState.nonDismissible);
 
 void main() => runApp(MyApp());
 
@@ -144,12 +148,12 @@ class _MyHomePageState extends State<MyHomePage> {
                               expand: true,
                               context: context,
                               backgroundColor: Colors.transparent,
-                              builder: (context) => ModalInsideModal(),
-                              // Change this to BottomSheetState.dismissible 
+                              builder: (context) =>
+                                  ModalInsideModalWithStateChangeNotifier(),
+                              // Change this to BottomSheetState.dismissible
                               // to see the difference
-                              changeInternalStateNotifier: ValueNotifier(
-                                BottomSheetState.nonDismissible,
-                              ),
+                              changeInternalStateNotifier:
+                                  bottomSheetStateNotifier,
                             )),
                     ListTile(
                         title: Text('Avatar Modal'),

--- a/example/lib/modals/modal_with_notifier.dart
+++ b/example/lib/modals/modal_with_notifier.dart
@@ -1,0 +1,101 @@
+import 'package:example/main.dart';
+import 'package:example/modals/modal_inside_modal.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
+
+/// Stateful widget that lets you create a bottom sheet which can change
+/// state based on the switch.
+class ModalInsideModalWithStateChangeNotifier extends StatefulWidget {
+  final bool reverse;
+
+  const ModalInsideModalWithStateChangeNotifier(
+      {Key? key, this.reverse = false})
+      : super(key: key);
+
+  @override
+  State<ModalInsideModalWithStateChangeNotifier> createState() =>
+      _ModalInsideModalWithStateChangeNotifierState();
+}
+
+class _ModalInsideModalWithStateChangeNotifierState
+    extends State<ModalInsideModalWithStateChangeNotifier> {
+  bool switchValue = true;
+
+  @override
+  void initState() {
+    // This piece of code is written here so that we can open the bottomsheet
+    // with the bottomsheet in a non-dismissible state.
+    // Note : This is just for demo.
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+      bottomSheetStateNotifier.value = BottomSheetState.nonDismissible;
+    });
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+        child: CupertinoPageScaffold(
+      navigationBar: CupertinoNavigationBar(
+          leading: Container(), middle: Text('Modal Page')),
+      child: SafeArea(
+        bottom: false,
+        child: Column(
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                Text(
+                  'Lock the Bottom Sheet',
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                    fontSize: 15,
+                  ),
+                ),
+                Switch(
+                  value: switchValue,
+                  onChanged: (value) {
+                    if (value) {
+                      bottomSheetStateNotifier.value =
+                          BottomSheetState.nonDismissible;
+                    } else {
+                      bottomSheetStateNotifier.value =
+                          BottomSheetState.dismissible;
+                    }
+                    setState(() {
+                      switchValue = value;
+                    });
+                  },
+                ),
+              ],
+            ),
+            Expanded(
+              child: ListView(
+                reverse: widget.reverse,
+                shrinkWrap: true,
+                controller: ModalScrollController.of(context),
+                physics: ClampingScrollPhysics(),
+                children: ListTile.divideTiles(
+                    context: context,
+                    tiles: List.generate(
+                      100,
+                      (index) => ListTile(
+                          title: Text('Item $index'),
+                          onTap: () => showCupertinoModalBottomSheet(
+                                expand: true,
+                                isDismissible: false,
+                                context: context,
+                                backgroundColor: Colors.transparent,
+                                builder: (context) =>
+                                    ModalInsideModal(reverse: widget.reverse),
+                              )),
+                    )).toList(),
+              ),
+            ),
+          ],
+        ),
+      ),
+    ));
+  }
+}

--- a/lib/modal_bottom_sheet.dart
+++ b/lib/modal_bottom_sheet.dart
@@ -5,3 +5,5 @@ export 'src/bottom_sheets/cupertino_bottom_sheet.dart';
 export 'src/bottom_sheets/material_bottom_sheet.dart';
 export 'src/bottom_sheets/bar_bottom_sheet.dart';
 export 'src/utils/modal_scroll_controller.dart';
+export 'src/utils/bottom_sheet_states.dart';
+

--- a/lib/src/bottom_sheet.dart
+++ b/lib/src/bottom_sheet.dart
@@ -192,7 +192,19 @@ class _ModalBottomSheetState extends State<ModalBottomSheet>
 
   void _handleDragUpdate(double primaryDelta) async {
     animationCurve = Curves.linear;
-    assert(widget.enableDrag, 'Dragging is disabled');
+    if (widget.bottomSheetStateNotifier?.value != null) {
+      if (widget.enableDrag &&
+          (widget.bottomSheetStateNotifier?.value ==
+              BottomSheetState.dismissible)) {
+      } else {
+        return;
+      }
+    } else {
+      assert(
+        widget.enableDrag,
+        'Dragging is disabled',
+      );
+    }
 
     if (_dismissUnderway) return;
     isDragging = true;
@@ -223,7 +235,19 @@ class _ModalBottomSheetState extends State<ModalBottomSheet>
   }
 
   void _handleDragEnd(double velocity) async {
-    assert(widget.enableDrag, 'Dragging is disabled');
+    if (widget.bottomSheetStateNotifier?.value != null) {
+      if (widget.enableDrag &&
+          (widget.bottomSheetStateNotifier?.value ==
+              BottomSheetState.dismissible)) {
+      } else {
+        return;
+      }
+    } else {
+      assert(
+        widget.enableDrag,
+        'Dragging is disabled',
+      );
+    }
 
     animationCurve = BottomSheetSuspendedCurve(
       widget.animationController.value,

--- a/lib/src/bottom_sheet.dart
+++ b/lib/src/bottom_sheet.dart
@@ -10,6 +10,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 import 'package:modal_bottom_sheet/src/utils/scroll_to_top_status_bar.dart';
+import 'package:modal_bottom_sheet/src/utils/bottom_sheet_states.dart';
 
 import 'package:modal_bottom_sheet/src/utils/bottom_sheet_suspended_curve.dart';
 
@@ -45,6 +46,7 @@ class ModalBottomSheet extends StatefulWidget {
     this.containerBuilder,
     this.bounce = true,
     this.shouldClose,
+    this.bottomSheetStateNotifier,
     required this.scrollController,
     required this.expanded,
     required this.onClosing,
@@ -106,6 +108,8 @@ class ModalBottomSheet extends StatefulWidget {
   final bool enableDrag;
 
   final ScrollController scrollController;
+
+  final ValueNotifier<BottomSheetState>? bottomSheetStateNotifier;
 
   @override
   _ModalBottomSheetState createState() => _ModalBottomSheetState();

--- a/lib/src/bottom_sheet.dart
+++ b/lib/src/bottom_sheet.dart
@@ -192,11 +192,12 @@ class _ModalBottomSheetState extends State<ModalBottomSheet>
 
   void _handleDragUpdate(double primaryDelta) async {
     animationCurve = Curves.linear;
+
+    // If notifier is provided, then disabling the drag depends on the value
+    // of the notifier.
     if (widget.bottomSheetStateNotifier?.value != null) {
-      if (widget.enableDrag &&
-          (widget.bottomSheetStateNotifier?.value ==
-              BottomSheetState.dismissible)) {
-      } else {
+      if (widget.bottomSheetStateNotifier?.value ==
+          BottomSheetState.nonDismissible) {
         return;
       }
     } else {
@@ -235,11 +236,11 @@ class _ModalBottomSheetState extends State<ModalBottomSheet>
   }
 
   void _handleDragEnd(double velocity) async {
+    // If notifier is provided, then disabling the drag depends on the value
+    // of the notifier.
     if (widget.bottomSheetStateNotifier?.value != null) {
-      if (widget.enableDrag &&
-          (widget.bottomSheetStateNotifier?.value ==
-              BottomSheetState.dismissible)) {
-      } else {
+      if (widget.bottomSheetStateNotifier?.value ==
+          BottomSheetState.nonDismissible) {
         return;
       }
     } else {

--- a/lib/src/bottom_sheet_route.dart
+++ b/lib/src/bottom_sheet_route.dart
@@ -6,6 +6,8 @@ import '../modal_bottom_sheet.dart';
 
 const Duration _bottomSheetDuration = Duration(milliseconds: 400);
 
+/// A route for displaying modal bottom sheet that uses a notifier to
+/// change the internal state.
 class ModalBottomSheetRouteWithNotifier<T> extends PopupRoute<T> {
   ModalBottomSheetRouteWithNotifier({
     this.closeProgressThreshold,
@@ -27,6 +29,7 @@ class ModalBottomSheetRouteWithNotifier<T> extends PopupRoute<T> {
     isDismissible =
         changeInternalStateNotifier.value == BottomSheetState.dismissible;
 
+    // Listen to the notifier to change the internal state.
     changeInternalStateNotifier.addListener(() {
       BottomSheetState bottomSheetState = changeInternalStateNotifier.value;
       if (bottomSheetState == BottomSheetState.dismissible) {

--- a/lib/src/bottom_sheet_route.dart
+++ b/lib/src/bottom_sheet_route.dart
@@ -142,11 +142,21 @@ class ModalBottomSheetRoute<T> extends PopupRoute<T> {
     this.bounce = false,
     this.animationCurve,
     this.duration,
+    this.changeInternalStateNotifier,
     RouteSettings? settings,
   })  : assert(expanded != null),
         assert(isDismissible != null),
         assert(enableDrag != null),
-        super(settings: settings);
+        super(settings: settings) {
+    changeInternalStateNotifier?.addListener(() {
+      if (changeInternalStateNotifier?.value != null) {
+        if (changeInternalStateNotifier?.value == true) {
+          isDismissible = false;
+          super.changedInternalState();
+        }
+      }
+    });
+  }
 
   final double? closeProgressThreshold;
   final WidgetWithChildBuilder? containerBuilder;
@@ -154,9 +164,10 @@ class ModalBottomSheetRoute<T> extends PopupRoute<T> {
   final bool expanded;
   final bool bounce;
   final Color? modalBarrierColor;
-  final bool isDismissible;
+  bool isDismissible;
   final bool enableDrag;
   final ScrollController? scrollController;
+  final ValueNotifier? changeInternalStateNotifier;
 
   final Duration? duration;
 

--- a/lib/src/bottom_sheet_route.dart
+++ b/lib/src/bottom_sheet_route.dart
@@ -6,8 +6,122 @@ import '../modal_bottom_sheet.dart';
 
 const Duration _bottomSheetDuration = Duration(milliseconds: 400);
 
-class _ModalBottomSheet<T> extends StatefulWidget {
-  const _ModalBottomSheet({
+class ModalBottomSheetRouteWithNotifier<T> extends PopupRoute<T> {
+  ModalBottomSheetRouteWithNotifier({
+    this.closeProgressThreshold,
+    this.containerBuilder,
+    required this.builder,
+    this.scrollController,
+    this.barrierLabel,
+    this.secondAnimationController,
+    this.modalBarrierColor,
+    this.isDismissible = true,
+    this.enableDrag = true,
+    required this.expanded,
+    this.bounce = false,
+    this.animationCurve,
+    this.duration,
+    required this.changeInternalStateNotifier,
+    RouteSettings? settings,
+  }) : super(settings: settings) {
+    isDismissible =
+        changeInternalStateNotifier.value == BottomSheetState.dismissible;
+
+    changeInternalStateNotifier.addListener(() {
+      BottomSheetState bottomSheetState = changeInternalStateNotifier.value;
+      if (bottomSheetState == BottomSheetState.dismissible) {
+        isDismissible = true;
+      } else {
+        isDismissible = false;
+      }
+
+      super.changedInternalState();
+    });
+  }
+
+  final double? closeProgressThreshold;
+  final WidgetWithChildBuilder? containerBuilder;
+  final WidgetBuilder builder;
+  final bool expanded;
+  final bool bounce;
+  final Color? modalBarrierColor;
+  bool isDismissible;
+  final bool enableDrag;
+  final ScrollController? scrollController;
+  final ValueNotifier<BottomSheetState> changeInternalStateNotifier;
+
+  final Duration? duration;
+
+  final AnimationController? secondAnimationController;
+  final Curve? animationCurve;
+
+  @override
+  Duration get transitionDuration => duration ?? _bottomSheetDuration;
+
+  @override
+  bool get barrierDismissible => isDismissible;
+
+  @override
+  final String? barrierLabel;
+
+  @override
+  Color get barrierColor => modalBarrierColor ?? Colors.black.withOpacity(0.35);
+
+  AnimationController? _animationController;
+
+  @override
+  AnimationController createAnimationController() {
+    assert(_animationController == null);
+    _animationController = ModalBottomSheet.createAnimationController(
+      navigator!.overlay!,
+      duration: transitionDuration,
+    );
+    return _animationController!;
+  }
+
+  bool get _hasScopedWillPopCallback => hasScopedWillPopCallback;
+
+  @override
+  Widget buildPage(BuildContext context, Animation<double> animation,
+      Animation<double> secondaryAnimation) {
+    // By definition, the bottom sheet is aligned to the bottom of the page
+    // and isn't exposed to the top padding of the MediaQuery.
+    Widget bottomSheet = MediaQuery.removePadding(
+      context: context,
+      // removeTop: true,
+      child: _ModalBottomSheetWithNotifier<T>(
+        closeProgressThreshold: closeProgressThreshold,
+        changeInternalStateNotifier: changeInternalStateNotifier,
+        route: this,
+        secondAnimationController: secondAnimationController,
+        expanded: expanded,
+        bounce: bounce,
+        enableDrag: enableDrag,
+        animationCurve: animationCurve,
+      ),
+    );
+    return bottomSheet;
+  }
+
+  @override
+  bool canTransitionTo(TransitionRoute<dynamic> nextRoute) =>
+      nextRoute is ModalBottomSheetRoute;
+
+  @override
+  bool canTransitionFrom(TransitionRoute<dynamic> previousRoute) =>
+      previousRoute is ModalBottomSheetRoute || previousRoute is PageRoute;
+
+  Widget getPreviousRouteTransition(
+    BuildContext context,
+    Animation<double> secondAnimation,
+    Widget child,
+  ) {
+    return child;
+  }
+}
+
+class _ModalBottomSheetWithNotifier<T> extends StatefulWidget {
+  const _ModalBottomSheetWithNotifier({
     Key? key,
     this.closeProgressThreshold,
     required this.route,
@@ -20,7 +134,7 @@ class _ModalBottomSheet<T> extends StatefulWidget {
   }) : super(key: key);
 
   final double? closeProgressThreshold;
-  final ModalBottomSheetRoute<T> route;
+  final ModalBottomSheetRouteWithNotifier<T> route;
   final bool expanded;
   final bool bounce;
   final bool enableDrag;
@@ -29,10 +143,12 @@ class _ModalBottomSheet<T> extends StatefulWidget {
   final ValueNotifier<BottomSheetState>? changeInternalStateNotifier;
 
   @override
-  _ModalBottomSheetState<T> createState() => _ModalBottomSheetState<T>();
+  ___ModalBottomSheetWithNotifierState<T> createState() =>
+      ___ModalBottomSheetWithNotifierState<T>();
 }
 
-class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
+class ___ModalBottomSheetWithNotifierState<T>
+    extends State<_ModalBottomSheetWithNotifier<T>> {
   String _getRouteLabel() {
     final platform = Theme.of(context).platform; //?? defaultTargetPlatform;
     switch (platform) {
@@ -125,6 +241,122 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
   }
 }
 
+class _ModalBottomSheet<T> extends StatefulWidget {
+  const _ModalBottomSheet({
+    Key? key,
+    this.closeProgressThreshold,
+    required this.route,
+    this.secondAnimationController,
+    this.bounce = false,
+    this.expanded = false,
+    this.enableDrag = true,
+    this.animationCurve,
+  }) : super(key: key);
+
+  final double? closeProgressThreshold;
+  final ModalBottomSheetRoute<T> route;
+  final bool expanded;
+  final bool bounce;
+  final bool enableDrag;
+  final AnimationController? secondAnimationController;
+  final Curve? animationCurve;
+
+  @override
+  _ModalBottomSheetState<T> createState() => _ModalBottomSheetState<T>();
+}
+
+class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
+  String _getRouteLabel() {
+    final platform = Theme.of(context).platform; //?? defaultTargetPlatform;
+    switch (platform) {
+      case TargetPlatform.iOS:
+      case TargetPlatform.linux:
+      case TargetPlatform.macOS:
+      case TargetPlatform.windows:
+        return '';
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+        if (Localizations.of(context, MaterialLocalizations) != null) {
+          return MaterialLocalizations.of(context).dialogLabel;
+        } else {
+          return const DefaultMaterialLocalizations().dialogLabel;
+        }
+    }
+  }
+
+  ScrollController? _scrollController;
+
+  @override
+  void initState() {
+    widget.route.animation?.addListener(updateController);
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    widget.route.animation?.removeListener(updateController);
+    _scrollController?.dispose();
+    super.dispose();
+  }
+
+  void updateController() {
+    final animation = widget.route.animation;
+    if (animation != null) {
+      widget.secondAnimationController?.value = animation.value;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    assert(debugCheckHasMediaQuery(context));
+    assert(widget.route._animationController != null);
+    final scrollController = PrimaryScrollController.of(context) ??
+        (_scrollController ??= ScrollController());
+    return ModalScrollController(
+      controller: scrollController,
+      child: Builder(
+        builder: (context) => AnimatedBuilder(
+          animation: widget.route._animationController!,
+          builder: (BuildContext context, final Widget? child) {
+            assert(child != null);
+            // Disable the initial animation when accessible navigation is on so
+            // that the semantics are added to the tree at the correct time.
+            return Semantics(
+              scopesRoute: true,
+              namesRoute: true,
+              label: _getRouteLabel(),
+              explicitChildNodes: true,
+              child: ModalBottomSheet(
+                closeProgressThreshold: widget.closeProgressThreshold,
+                expanded: widget.route.expanded,
+                containerBuilder: widget.route.containerBuilder,
+                animationController: widget.route._animationController!,
+                shouldClose: widget.route._hasScopedWillPopCallback
+                    ? () async {
+                        final willPop = await widget.route.willPop();
+                        return willPop != RoutePopDisposition.doNotPop;
+                      }
+                    : null,
+                onClosing: () {
+                  if (widget.route.isCurrent) {
+                    Navigator.of(context).pop();
+                  }
+                },
+                enableDrag: widget.enableDrag,
+                bounce: widget.bounce,
+                scrollController: scrollController,
+                animationCurve: widget.animationCurve,
+                child: child!,
+              ),
+            );
+          },
+          child: widget.route.builder(context),
+        ),
+      ),
+    );
+  }
+}
+
 class ModalBottomSheetRoute<T> extends PopupRoute<T> {
   ModalBottomSheetRoute({
     this.closeProgressThreshold,
@@ -140,22 +372,8 @@ class ModalBottomSheetRoute<T> extends PopupRoute<T> {
     this.bounce = false,
     this.animationCurve,
     this.duration,
-    this.changeInternalStateNotifier,
     RouteSettings? settings,
-  }) : super(settings: settings) {
-    changeInternalStateNotifier?.addListener(() {
-      print(
-          'AG value: changeInternalStateNotifier ${changeInternalStateNotifier?.value}');
-      BottomSheetState bottomSheetState = changeInternalStateNotifier!.value;
-      if (bottomSheetState == BottomSheetState.dismissible) {
-        isDismissible = true;
-      } else {
-        isDismissible = false;
-      }
-
-      super.changedInternalState();
-    });
-  }
+  }) : super(settings: settings);
 
   final double? closeProgressThreshold;
   final WidgetWithChildBuilder? containerBuilder;
@@ -166,7 +384,6 @@ class ModalBottomSheetRoute<T> extends PopupRoute<T> {
   bool isDismissible;
   final bool enableDrag;
   final ScrollController? scrollController;
-  final ValueNotifier<BottomSheetState>? changeInternalStateNotifier;
 
   final Duration? duration;
 
@@ -209,7 +426,6 @@ class ModalBottomSheetRoute<T> extends PopupRoute<T> {
       // removeTop: true,
       child: _ModalBottomSheet<T>(
         closeProgressThreshold: closeProgressThreshold,
-        changeInternalStateNotifier: changeInternalStateNotifier,
         route: this,
         secondAnimationController: secondAnimationController,
         expanded: expanded,

--- a/lib/src/bottom_sheets/bar_bottom_sheet.dart
+++ b/lib/src/bottom_sheets/bar_bottom_sheet.dart
@@ -90,7 +90,7 @@ Future<T?> showBarModalBottomSheet<T>({
   Duration? duration,
   RouteSettings? routeSettings,
   ScrollController? scrollController,
-  ValueNotifier? changeInternalStateNotifier,
+  ValueNotifier<BottomSheetState>? changeInternalStateNotifier,
 }) async {
   assert(context != null);
   assert(builder != null);

--- a/lib/src/bottom_sheets/bar_bottom_sheet.dart
+++ b/lib/src/bottom_sheets/bar_bottom_sheet.dart
@@ -90,6 +90,7 @@ Future<T?> showBarModalBottomSheet<T>({
   Duration? duration,
   RouteSettings? routeSettings,
   ScrollController? scrollController,
+  ValueNotifier? changeInternalStateNotifier,
 }) async {
   assert(context != null);
   assert(builder != null);
@@ -103,6 +104,7 @@ Future<T?> showBarModalBottomSheet<T>({
       .push(ModalBottomSheetRoute<T>(
     builder: builder,
     bounce: bounce,
+    changeInternalStateNotifier: changeInternalStateNotifier,
     closeProgressThreshold: closeProgressThreshold,
     containerBuilder: (_, __, child) => BarBottomSheet(
       child: child,

--- a/lib/src/bottom_sheets/bar_bottom_sheet.dart
+++ b/lib/src/bottom_sheets/bar_bottom_sheet.dart
@@ -4,8 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import '../../modal_bottom_sheet.dart';
-import '../bottom_sheet_route.dart';
-
 const Radius _default_bar_top_radius = Radius.circular(15);
 
 class BarBottomSheet extends StatelessWidget {
@@ -70,6 +68,57 @@ class BarBottomSheet extends StatelessWidget {
   }
 }
 
+Future<T?> showBarModalBottomSheetWithNotifier<T>({
+  required BuildContext context,
+  required WidgetBuilder builder,
+  required ValueNotifier<BottomSheetState> changeInternalStateNotifier,
+  Color? backgroundColor,
+  double? elevation,
+  ShapeBorder? shape,
+  double? closeProgressThreshold,
+  Clip? clipBehavior,
+  Color barrierColor = Colors.black87,
+  bool bounce = true,
+  bool expand = false,
+  AnimationController? secondAnimation,
+  Curve? animationCurve,
+  bool useRootNavigator = false,
+  bool isDismissible = true,
+  bool enableDrag = true,
+  Widget? topControl,
+  Duration? duration,
+  RouteSettings? routeSettings,
+  ScrollController? scrollController,
+}) async {
+  assert(debugCheckHasMediaQuery(context));
+  assert(debugCheckHasMaterialLocalizations(context));
+  final result = await Navigator.of(context, rootNavigator: useRootNavigator)
+      .push(ModalBottomSheetRouteWithNotifier<T>(
+    builder: builder,
+    bounce: bounce,
+    changeInternalStateNotifier: changeInternalStateNotifier,
+    closeProgressThreshold: closeProgressThreshold,
+    containerBuilder: (_, __, child) => BarBottomSheet(
+      control: topControl,
+      clipBehavior: clipBehavior,
+      shape: shape,
+      elevation: elevation,
+      child: child,
+    ),
+    secondAnimationController: secondAnimation,
+    expanded: expand,
+    barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
+    isDismissible: isDismissible,
+    modalBarrierColor: barrierColor,
+    enableDrag: enableDrag,
+    animationCurve: animationCurve,
+    duration: duration,
+    settings: routeSettings,
+    scrollController: scrollController,
+  ));
+  return result;
+}
+
 Future<T?> showBarModalBottomSheet<T>({
   required BuildContext context,
   required WidgetBuilder builder,
@@ -90,7 +139,6 @@ Future<T?> showBarModalBottomSheet<T>({
   Duration? duration,
   RouteSettings? routeSettings,
   ScrollController? scrollController,
-  ValueNotifier<BottomSheetState>? changeInternalStateNotifier,
 }) async {
   assert(context != null);
   assert(builder != null);
@@ -104,7 +152,6 @@ Future<T?> showBarModalBottomSheet<T>({
       .push(ModalBottomSheetRoute<T>(
     builder: builder,
     bounce: bounce,
-    changeInternalStateNotifier: changeInternalStateNotifier,
     closeProgressThreshold: closeProgressThreshold,
     containerBuilder: (_, __, child) => BarBottomSheet(
       child: child,

--- a/lib/src/utils/bottom_sheet_states.dart
+++ b/lib/src/utils/bottom_sheet_states.dart
@@ -1,0 +1,4 @@
+enum BottomSheetState {
+  dismissible,
+  nonDismissible,
+}


### PR DESCRIPTION
Let me start by talking about the problem that I was facing:

I wanted a BottomSheet that can have two states (ie, both dismissible and non-dismissible) based on certain factors. Apparently a BottomSheet can be opened with only one state and it was immutable (ie, you can't change its state without opening a new one).

So, I came up with a solution :

I saw that we have some internal code that can help in changing the internal state of the bottom sheet but it was not exposed to the developers.
So, I created a new BottomSheet which I named `showBarModalBottomSheetWithNotifier` which has an additional parameter `changeInternalStateNotifier` which takes in a valueNotifier of type `BottomSheetState`.

Well, since we are creating a new bottom sheet, there are couple of more widgets that has to be re-created :

- `ModalBottomSheetRouteWithNotifier` which extends `PopRoute` to show the BottomSheet
- `_ModalBottomSheetWithNotifier` which is the StatefulWidget that defines the BottomSheet content

**Tests:**
Manual tests done and works as expected

**Screen-recording :**

https://user-images.githubusercontent.com/40236624/186640514-5ab79227-0dd3-4546-a9db-02b97a716925.mov

